### PR TITLE
Add licensing and attribution info to Brian's lessons

### DIFF
--- a/balanced-trees/avl-trees/lesson.md
+++ b/balanced-trees/avl-trees/lesson.md
@@ -208,3 +208,15 @@ Here are a few tips to keep in mind when working with AVL trees:
 - When checking the shape of the tree, you might be tempted to perform an in-order traversal. However, recall that AVL trees are BSTs, so the in-order traversal will be the same (in sorted order), regardless of whether the tree is balanced.
 - Calculating the height of a node can be a costly operation. Consider storing height information in each node to avoid recalculating the height of the same subtree multiple times.
 - Additionally, fix the height property of a node after relevant rotations.
+
+# References
+
+- [COP 3530 Instructional Content](https://github.com/COP3530/Instructional-Content)
+
+Graphics by Brian Magnuson.
+
+Lesson content written with AI assistance.
+
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/cpp-review/basics/lesson.md
+++ b/cpp-review/basics/lesson.md
@@ -645,3 +645,9 @@ That's it for this lesson! We've covered a lot of ground, but this is just the b
 
 - [C++ Reference](https://en.cppreference.com/w/cpp)
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+
+Lesson content written with AI assistance.
+
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/cpp-review/classes/lesson.md
+++ b/cpp-review/classes/lesson.md
@@ -627,3 +627,11 @@ That's it for this lesson! We've covered nearly everything you need to know abou
 
 - [C++ Reference](https://en.cppreference.com/w/cpp)
 - [GeeksForGeeks](https://www.geeksforgeeks.org/c-plus-plus/)
+
+Graphics by Brian Magnuson.
+
+Lesson content written with AI assistance.
+
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/cpp-review/containers/lesson.md
+++ b/cpp-review/containers/lesson.md
@@ -571,3 +571,9 @@ And that's it for this lesson on C++ containers! In this lesson, we've only cove
 # References
 
 - [C++ Reference](https://en.cppreference.com/w/cpp)
+
+Lesson content written with AI assistance.
+
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/cpp-review/memory/lesson.md
+++ b/cpp-review/memory/lesson.md
@@ -390,3 +390,11 @@ That's all for this lesson. We've covered the memory model, pointers, arrays, an
 
 - [C++ Reference](https://en.cppreference.com/w/cpp)
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+
+Graphics by Brian Magnuson.
+
+Lesson content written with AI assistance.
+
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/heaps/heaps/lesson.md
+++ b/heaps/heaps/lesson.md
@@ -498,4 +498,6 @@ Graphics by Brian Magnuson.
 
 Lesson content written with AI assistance.
 
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
 Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/sets-maps-hash-tables/hash-tables/lesson.md
+++ b/sets-maps-hash-tables/hash-tables/lesson.md
@@ -390,4 +390,6 @@ Graphics by Brian Magnuson.
 
 Lesson content written with AI assistance.
 
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
 Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/sets-maps-hash-tables/sets-and-maps/lesson.md
+++ b/sets-maps-hash-tables/sets-and-maps/lesson.md
@@ -626,4 +626,6 @@ Finally, we briefly discussed sets and maps in other programming languages.
 
 Lesson content written with AI assistance.
 
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
 Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

--- a/sorting/sorting/lesson.md
+++ b/sorting/sorting/lesson.md
@@ -538,4 +538,6 @@ Graphics by Brian Magnuson.
 
 Lesson content written with AI assistance.
 
+This work by Brian Magnuson is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
 Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!


### PR DESCRIPTION
In short, this PR adds licensing and attribution information to the lessons by @Brian-Magnuson that did not already have such information. This mainly affects older lessons, when the formatting for the inclusion of this information was not well established at the time.

Later lessons have a footer section that looks roughly like this:

> # References
> 
> - [Cppreference](https://en.cppreference.com/)
> - [Other references](https://example.com/)
> 
> Graphics by (Author).
> 
> This work by (Author) is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
> 
> Find a mistake? Open an issue on [GitHub](https://github.com/COP3530/edugator-content/issues)!

Old lessons have been updated to follow this format.